### PR TITLE
Fix: Remove Frontend Fallback Authentication

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -59,64 +59,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         }
       }
       
-      // If no proper response, try with demo data for testing
-      if (credentials.email && credentials.password) {
-        // Demo user for testing
-        const demoUser: User = {
-          id: '1',
-          email: credentials.email,
-          name: 'Demo User',
-          role: credentials.email.includes('admin') ? 'super_admin' as any : 'receptionist' as any,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString()
-        };
-        
-        const demoToken = 'demo_token_' + Date.now();
-        
-        localStorage.setItem('auth_token', demoToken);
-        localStorage.setItem('user_data', JSON.stringify(demoUser));
-        
-        setAuthState({
-          user: demoUser,
-          token: demoToken,
-          isAuthenticated: true,
-          isLoading: false,
-        });
-        
-        return true;
-      }
-      
       setAuthState(prev => ({ ...prev, isLoading: false }));
       return false;
     } catch (error) {
       console.error('Login error:', error);
-      
-      // Fallback to demo mode if backend is not responding
-      if (credentials.email && credentials.password) {
-        const demoUser: User = {
-          id: '1',
-          email: credentials.email,
-          name: 'Demo User',
-          role: credentials.email.includes('admin') ? 'super_admin' as any : 'receptionist' as any,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString()
-        };
-        
-        const demoToken = 'demo_token_' + Date.now();
-        
-        localStorage.setItem('auth_token', demoToken);
-        localStorage.setItem('user_data', JSON.stringify(demoUser));
-        
-        setAuthState({
-          user: demoUser,
-          token: demoToken,
-          isAuthenticated: true,
-          isLoading: false,
-        });
-        
-        return true;
-      }
-      
       setAuthState(prev => ({ ...prev, isLoading: false }));
       return false;
     }


### PR DESCRIPTION
This change fixes a critical security vulnerability that allowed users to log in with any credentials.

The root cause was frontend logic in `src/contexts/AuthContext.tsx` that created a mock "demo" user session if the backend authentication API call failed. This effectively bypassed the backend's credential verification.

The fix removes this fallback behavior entirely. The application now strictly relies on a successful response from the backend API to authenticate a user, ensuring that only valid credentials grant access.